### PR TITLE
Ffmpeg

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -88,7 +88,7 @@ jobs:
           path: artifact
 
       - name: Upload GH Release Assets
-        uses: shogo82148/actions-upload-release-asset@59cbc563d11314e48122193f8fe5cdda62ea6cf9 # v1.9.1
+        uses: shogo82148/actions-upload-release-asset@8f6863c6c894ba46f9e676ef5cccec4752723c1e # v1.9.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
           overwrite: true

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -81,7 +81,7 @@ jobs:
           path: artifact
 
       - name: Upload GH Release Assets
-        uses: shogo82148/actions-upload-release-asset@59cbc563d11314e48122193f8fe5cdda62ea6cf9 # v1.9.1
+        uses: shogo82148/actions-upload-release-asset@8f6863c6c894ba46f9e676ef5cccec4752723c1e # v1.9.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
           overwrite: true

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -94,7 +94,7 @@ jobs:
           path: artifact
 
       - name: Upload GH Release Assets
-        uses: shogo82148/actions-upload-release-asset@59cbc563d11314e48122193f8fe5cdda62ea6cf9 # v1.9.1
+        uses: shogo82148/actions-upload-release-asset@8f6863c6c894ba46f9e676ef5cccec4752723c1e # v1.9.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
           overwrite: true

--- a/.github/workflows/_meta_win_clang_portable.yaml
+++ b/.github/workflows/_meta_win_clang_portable.yaml
@@ -103,7 +103,7 @@ jobs:
           path: artifact
 
       - name: Upload GH Release Assets
-        uses: shogo82148/actions-upload-release-asset@59cbc563d11314e48122193f8fe5cdda62ea6cf9 # v1.9.1
+        uses: shogo82148/actions-upload-release-asset@8f6863c6c894ba46f9e676ef5cccec4752723c1e # v1.9.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
           overwrite: true

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="2e31630bce69ba975ad3d7ef551debada09434a4"
+SCRIPT_COMMIT="2de6703961c0d519046b841f7b392a040e1e5b55"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-zlib.sh
+++ b/builder/scripts.d/20-zlib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/madler/zlib.git"
-SCRIPT_COMMIT="5a82f71ed1dfc0bec044d9702463dbdf84ea3b71"
+SCRIPT_COMMIT="570720b0c24f9686c33f35a1b3165c1f568b96be"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
-SCRIPT_COMMIT="adde9bec41206a3d6bbb02bdbf9f64726d7d2009"
+SCRIPT_COMMIT="7947c101a5b724fe8b9784218388b46d7e247132"
 
 ffbuild_enabled() {
     # Dependency of GPL-Only librubberband

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/freetype/freetype.git"
-SCRIPT_COMMIT="03acd8923bd8a45ce8edaf06f5194b48becbad7f"
+SCRIPT_COMMIT="23b6cd27ff19b70cbf98e058cd2cf0647d5284ff"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/BtbN/gmplib.git"
-SCRIPT_COMMIT="ece1292e8282ef2c9ca204d1b510ff2aca04a7a3"
+SCRIPT_COMMIT="9994908f090c694f8a152d660dc6852e0c48557a"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-libxml2.sh
+++ b/builder/scripts.d/25-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="48df82f6ea004fa8fdd0587e458d66d0bf509e7c"
+SCRIPT_COMMIT="9827e6e44652555992e168609abf94e4237ca944"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-openssl.sh
+++ b/builder/scripts.d/25-openssl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/openssl/openssl.git"
-SCRIPT_COMMIT="openssl-3.4.2"
+SCRIPT_COMMIT="openssl-3.4.3"
 SCRIPT_TAGFILTER="openssl-3.4.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/25-xz.sh
+++ b/builder/scripts.d/25-xz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/tukaani-project/xz.git"
-SCRIPT_COMMIT="v5.8.1"
+SCRIPT_COMMIT="v5.8.2"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/45-libvorbis.sh
+++ b/builder/scripts.d/45-libvorbis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/vorbis.git"
-SCRIPT_COMMIT="43bbff0141028e58d476c1d5fd45dd5573db576d"
+SCRIPT_COMMIT="2d79800b6751dddd4b8b4ad50832faa5ae2a00d9"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xcbproto.sh
+++ b/builder/scripts.d/45-x11/10-xcbproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
-SCRIPT_COMMIT="c70aba5cc6ae87757111dac737fc814b3605f0d4"
+SCRIPT_COMMIT="283ead0904eb8c6350cef67dd638bb4a6b014c3a"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="57a10982c182ad68486815b3741d3aa3097c7460"
+SCRIPT_COMMIT="c18d2bc22813793bba7f0e4e603c0104d7724802"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="e81b999a727d3c8ee9b83adb7c1c822f67378687"
+SCRIPT_COMMIT="93ee2ac73c32dcb567259fb83c564a424cd9fef7"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="503e5aa44ae2beca60202fba5e7cd027bce0337c"
+SCRIPT_COMMIT="369c6a806554429798b531cbf4267d8c8fcf6ed1"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxext.sh
+++ b/builder/scripts.d/45-x11/50-libxext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxext.git"
-SCRIPT_COMMIT="a43b0df438b1cfb6516695aac4dad2436c0b4c60"
+SCRIPT_COMMIT="5ce2a6127889834082147dbcdd47731b7986961b"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
-SCRIPT_COMMIT="5e3b7dfb4ff40ec62f9e8c18d308eb6dcef342d3"
+SCRIPT_COMMIT="afed28d37aca1938da2eedc50599bb3535a987ec"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="0bc6bd93417179cd0c30fac40d2fd11aa29c8523"
+SCRIPT_COMMIT="a31e4bd75787c451301d66e888c76ada54544a0c"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="534a5f8299c5ab3c2782856fcb843bfea47b7afc"
+SCRIPT_COMMIT="cbb743215bad0fe202477e569fe8005545258ccd"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libbluray.sh
+++ b/builder/scripts.d/50-libbluray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libbluray.git"
-SCRIPT_COMMIT="d41111c1eb05a278f8dc37fb220d6ef9a13e3291"
+SCRIPT_COMMIT="71c5324e78dc7a159cad67ea7967300db54ec21c"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="b5dc74f26ff9a9ef1f1af9a473b9ae07520eed7d"
+SCRIPT_COMMIT="59f13a3eb0eed3a56cf46bd68cc2f29f18d83ba2"
 
 ffbuild_enabled() {
     return 0
@@ -10,9 +10,6 @@ ffbuild_enabled() {
 ffbuild_dockerbuild() {
     git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" opus
     cd opus
-
-    # Fix AVX2 auto detction
-    wget -q -O - https://github.com/xiph/opus/commit/9ec11c1.patch | git apply
 
     ./autogen.sh
 

--- a/builder/scripts.d/50-libvpl.sh
+++ b/builder/scripts.d/50-libvpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libvpl.git"
-SCRIPT_COMMIT="3591aa94dfbdf4566cd19f3e976ae5b769ab4fa2"
+SCRIPT_COMMIT="778a66d6c6537f08eabb91955dbbf1bce3812894"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="84e8b23bd7d27b4d2cd6135744986037cd529a9d"
+SCRIPT_COMMIT="d5399cdd6abea1169a246f28c5ca9a50975d7ba9"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="3779daa97f89e007e2c8121a8d4b514ad6dcda56"
+SCRIPT_COMMIT="d52b9ee34d6bb8fb7a190fe359d8560cfc2afc91"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="24185"
+SCRIPT_REV="24747"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-rkmpp.sh
+++ b/builder/scripts.d/50-rkmpp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://github.com/nyanmisaka/mpp.git"
-SCRIPT_COMMIT="4e5b4cfe7fa30394c5d5c37b67229f148865ccbd"
+SCRIPT_REPO="https://github.com/nyanmisaka/rk-mirrors.git"
+SCRIPT_COMMIT="a9380ef333102ac318628f83b5f7a460d377749e"
 SCRIPT_BRANCH="jellyfin-mpp-next"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="bab403744b4d02005b03dac12a79988bc4590038"
+SCRIPT_COMMIT="72f0c6e0e9a186adec428a145f4e085412d96796"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="76a1e97a9a7c29fa3035bb370d654791bdc23d90"
+SCRIPT_COMMIT="6bfcfc725fbe0ece0918535556d61ee567b1ffff"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="217da1c28336d6a7e9c0c4cb8f1c303968a675f1"
+SCRIPT_COMMIT="dbf83dc3b1ce6bad46e1628aaf2da5ef731157b8"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.4.326"
+SCRIPT_COMMIT="v1.4.337"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="3362e24c42ab5bf7ad32c0fec64b0a0ddeb2fda1"
+SCRIPT_COMMIT="c4b0af6c3664cd8b33ffddf452514e02a173b4d6"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="b26ac3fa8bcfe76c361b56e3284b5276b23453ce"
+SCRIPT_COMMIT="28184c1e138f18c330256eeb2f56b9f9fbc53921"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-zimg.sh
+++ b/builder/scripts.d/50-zimg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/sekrit-twc/zimg.git"
-SCRIPT_COMMIT="1f53009abc448781042fec90326294e7e55a4a16"
+SCRIPT_COMMIT="df9c1472b9541d0e79c8d02dae37fdf12f189ec2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-zvbi.sh
+++ b/builder/scripts.d/50-zvbi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/zapping-vbi/zvbi.git"
-SCRIPT_COMMIT="5169a428d51c3ae8ff7b0897e8a687d8e05e37b5"
+SCRIPT_COMMIT="41477c97c8edf7a01f1594b2a95b94f0117eed21"
 
 ffbuild_enabled() {
     return 0

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -47,7 +47,7 @@ popd
 popd
 
 # LIBXML2
-git clone -b v2.15.0 --depth=1 https://github.com/GNOME/libxml2.git
+git clone -b v2.15.1 --depth=1 https://github.com/GNOME/libxml2.git
 pushd libxml2
 ./autogen.sh \
     --prefix=${FF_DEPS_PREFIX} \
@@ -156,7 +156,7 @@ popd
 popd
 
 # LZMA
-git clone -b v5.8.1 --depth=1 https://github.com/tukaani-project/xz.git
+git clone -b v5.8.2 --depth=1 https://github.com/tukaani-project/xz.git
 pushd xz
 ./autogen.sh --no-po4a --no-doxygen
 ./configure \
@@ -333,7 +333,7 @@ popd
 # OPENMPT
 mkdir mpt
 pushd mpt
-mpt_ver="0.8.3"
+mpt_ver="0.8.4"
 mpt_link="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${mpt_ver}+release.autotools.tar.gz"
 wget ${mpt_link} -O mpt.tar.gz
 tar xaf mpt.tar.gz
@@ -486,7 +486,7 @@ popd
 popd
 
 # DAV1D
-git clone -b 1.5.1 --depth=1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 1.5.2 --depth=1 https://code.videolan.org/videolan/dav1d.git
 meson setup dav1d dav1d_build \
     --prefix=${FF_DEPS_PREFIX} \
     --cross-file=${FF_MESON_TOOLCHAIN} \
@@ -570,7 +570,7 @@ popd
 popd
 
 # VPL
-git clone -b v2.15.0 --depth=1 https://github.com/intel/libvpl.git
+git clone -b v2.16.0 --depth=1 https://github.com/intel/libvpl.git
 pushd libvpl
 mkdir build && pushd build
 cmake \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -61,7 +61,7 @@ prepare_extra_common() {
 
     # LIBXML2
     pushd ${SOURCE_DIR}
-    libxml2_ver="v2.15.0"
+    libxml2_ver="v2.15.1"
     git clone -b ${libxml2_ver} --depth=1 https://github.com/GNOME/libxml2.git
     pushd libxml2
     ./autogen.sh \
@@ -242,7 +242,7 @@ prepare_extra_common() {
 
     # DAV1D
     pushd ${SOURCE_DIR}
-    git clone -b 1.5.1 --depth=1 https://code.videolan.org/videolan/dav1d.git
+    git clone -b 1.5.2 --depth=1 https://code.videolan.org/videolan/dav1d.git
     meson setup dav1d dav1d_build \
         ${MESON_CROSS_OPT} \
         --prefix=${TARGET_DIR} \
@@ -325,7 +325,7 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     mkdir libdrm
     pushd libdrm
-    libdrm_ver="2.4.125"
+    libdrm_ver="2.4.131"
     libdrm_link="https://dri.freedesktop.org/libdrm/libdrm-${libdrm_ver}.tar.xz"
     wget ${libdrm_link} -O libdrm.tar.xz
     tar xaf libdrm.tar.xz
@@ -347,7 +347,7 @@ prepare_extra_amd64() {
 
     # LIBVA
     pushd ${SOURCE_DIR}
-    git clone -b 2.22.0 --depth=1 https://github.com/intel/libva.git
+    git clone -b 2.23.0 --depth=1 https://github.com/intel/libva.git
     pushd libva
     sed -i 's|secure_getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
     sed -i 's|secure_getenv("LIBVA_DRIVER_NAME")|secure_getenv("LIBVA_DRIVER_NAME_JELLYFIN")|g' va/va.c
@@ -364,7 +364,7 @@ prepare_extra_amd64() {
 
     # LIBVA-UTILS
     pushd ${SOURCE_DIR}
-    git clone -b 2.22.0 --depth=1 https://github.com/intel/libva-utils.git
+    git clone -b 2.23.0 --depth=1 https://github.com/intel/libva-utils.git
     pushd libva-utils
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR}
@@ -388,7 +388,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.8.2 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.9.0 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -426,7 +426,7 @@ prepare_extra_amd64() {
     # Provides VPL header and dispatcher (libvpl.so.2) for FFmpeg
     # Both MSDK and VPL runtime can be loaded by VPL dispatcher
     pushd ${SOURCE_DIR}
-    git clone -b v2.15.0 --depth=1 https://github.com/intel/libvpl.git
+    git clone -b v2.16.0 --depth=1 https://github.com/intel/libvpl.git
     pushd libvpl
     sed -i 's|ParseEnvSearchPaths(ONEVPL_PRIORITY_PATH_VAR, searchDirList)|searchDirList.push_back("/usr/lib/jellyfin-ffmpeg/lib")|g' libvpl/src/mfx_dispatcher_vpl_loader.cpp
     mkdir build && pushd build
@@ -448,7 +448,7 @@ prepare_extra_amd64() {
     # VPL-GPU-RT (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-25.4.4 --depth=1 https://github.com/intel/vpl-gpu-rt.git
+    git clone -b intel-onevpl-25.4.6 --depth=1 https://github.com/intel/vpl-gpu-rt.git
     pushd vpl-gpu-rt
     # Fix missing entries in PicStruct validation
     wget -q -O - https://github.com/intel/vpl-gpu-rt/commit/c7eb030.patch | git apply
@@ -470,7 +470,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-25.4.4 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-25.4.6 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Enable VC1 decode on DG2 (note that MTL+ is not supported)
     wget -q -O - https://github.com/intel/media-driver/commit/25fb926.patch | git apply
@@ -491,7 +491,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.326 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.4.337 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -504,7 +504,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.326 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.4.337 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -524,7 +524,7 @@ prepare_extra_amd64() {
     popd
 
     # SHADERC
-    shaderc_ver="v2025.3"
+    shaderc_ver="v2025.5"
     pushd ${SOURCE_DIR}
     git clone -b ${shaderc_ver} --depth=1 https://github.com/google/shaderc.git
     pushd shaderc
@@ -649,7 +649,7 @@ prepare_extra_amd64() {
 prepare_extra_arm() {
     # RKMPP
     pushd ${SOURCE_DIR}
-    git clone -b jellyfin-mpp-next --depth=1 https://github.com/nyanmisaka/mpp.git rkmpp
+    git clone -b jellyfin-mpp-next --depth=1 https://github.com/nyanmisaka/rk-mirrors.git rkmpp
     pushd rkmpp
     mkdir rkmpp_build
     pushd rkmpp_build
@@ -661,7 +661,7 @@ prepare_extra_arm() {
         -DBUILD_TEST=OFF \
         ..
     make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/rkmpp
-    echo "rkmpp${TARGET_DIR}/lib/librockchip*.* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
+    echo "rkmpp${TARGET_DIR}/lib/librockchip_mpp.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
     popd
     popd
     popd

--- a/msys2/PKGBUILD/10-mingw-w64-xz/PKGBUILD
+++ b/msys2/PKGBUILD/10-mingw-w64-xz/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=xz
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}"
-pkgver=5.8.1
+pkgver=5.8.2
 pkgrel=1
 pkgdesc="Library and command line tools for XZ and LZMA compressed files (mingw-w64)"
 arch=('any')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "po4a")
 source=("https://github.com/tukaani-project/xz/releases/download/v${pkgver}/xz-${pkgver}.tar.xz")
-sha256sums=('0b54f79df85912504de0b14aec7971e3f964491af1812d83447005807513cd9e')
+sha256sums=('890966ec3f5d5cc151077879e157c0593500a522f413ac50ba26d22a9a145214')
 validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620') # Lasse Collin <lasse.collin@tukaani.org>
 
 export FF_MINGW_PREFIX="${MINGW_PREFIX}/ffbuild"

--- a/msys2/PKGBUILD/20-mingw-w64-libxml2/PKGBUILD
+++ b/msys2/PKGBUILD/20-mingw-w64-libxml2/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libxml2
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=2.15.0
+pkgver=2.15.1
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -27,7 +27,7 @@ source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${_realname}-${
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
         0027-decoding-segfault.patch
 	0029-xml2-config-win-paths.patch)
-sha256sums=('5abc766497c5b1d6d99231f662e30c99402a90d03b06c67b62d6c1179dedd561'
+sha256sums=('c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9'
 	    '278b4531da3d2aabda080c412c5122b471202dd6df67768b38bb0c31c7a0e508')

--- a/msys2/PKGBUILD/30-mingw-w64-opus/001-aarch64-features.patch
+++ b/msys2/PKGBUILD/30-mingw-w64-opus/001-aarch64-features.patch
@@ -1,7 +1,8 @@
-diff -bur opus-1.5.1-orig/celt/arm/armcpu.c opus-1.5.1/celt/arm/armcpu.c
---- opus-1.5.1-orig/celt/arm/armcpu.c	2024-03-09 21:13:23.646469400 -0700
-+++ opus-1.5.1/celt/arm/armcpu.c	2024-03-09 22:51:55.794039700 -0700
-@@ -191,6 +191,31 @@
+diff --git a/celt/arm/armcpu.c b/celt/arm/armcpu.c
+index f03408c..e9f9dff 100644
+--- a/celt/arm/armcpu.c
++++ b/celt/arm/armcpu.c
+@@ -271,6 +271,31 @@ static opus_uint32 opus_cpu_capabilities(void)
    return flags;
  }
  
@@ -20,7 +21,7 @@ diff -bur opus-1.5.1-orig/celt/arm/armcpu.c opus-1.5.1/celt/arm/armcpu.c
 +    flags |= OPUS_CPU_ARM_EDSP_FLAG | OPUS_CPU_ARM_MEDIA_FLAG | OPUS_CPU_ARM_NEON_FLAG;
 +
 +#  if defined(OPUS_ARM_MAY_HAVE_DOTPROD)
-+  
++
 +  if (IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE))
 +  {
 +    flags |= OPUS_CPU_ARM_DOTPROD_FLAG;
@@ -32,4 +33,7 @@ diff -bur opus-1.5.1-orig/celt/arm/armcpu.c opus-1.5.1/celt/arm/armcpu.c
 +
  #else
  /* The feature registers which can tell us what the processor supports are
-  * accessible in priveleged modes only, so we can't have a general user-space
+  * accessible in privileged modes only, so we can't have a general user-space
+-- 
+2.34.1
+

--- a/msys2/PKGBUILD/30-mingw-w64-opus/PKGBUILD
+++ b/msys2/PKGBUILD/30-mingw-w64-opus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=opus
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=1.5.2
+pkgver=1.6
 pkgrel=1
 pkgdesc="Codec designed for interactive speech and audio transmission over the Internet (mingw-w64)"
 arch=('any')
@@ -22,8 +22,8 @@ makedepends=(
 )
 source=("https://downloads.xiph.org/releases/opus/opus-${pkgver}.tar.gz"
         001-aarch64-features.patch)
-sha256sums=('65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1'
-            '5fb0f28264492d6512acb6eec7b5e147c922751f6df30d1317114048eca01516')
+sha256sums=('b7637334527201fdfd6dd6a02e67aceffb0e5e60155bbd89175647a80301c92c'
+            'a579c6d0e80632bfc144e4338a560f1a4f45b1a9b431aa71d0ea4c7259bdbe05')
 
 export MINGW_TOOLCHAIN_PREFIX="${MINGW_PREFIX}"
 export FF_MINGW_PREFIX="${MINGW_TOOLCHAIN_PREFIX}/ffbuild"

--- a/msys2/PKGBUILD/40-mingw-w64-dav1d/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-dav1d/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dav1d
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=1.5.1
+pkgver=1.5.2
 pkgrel=1
 pkgdesc="AV1 cross-platform decoder focused on speed and correctness (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-xxhash")
 source=("https://downloads.videolan.org/pub/videolan/dav1d/${pkgver}/dav1d-${pkgver}.tar.xz"{,.asc}
         "0001-dll-version.patch")
-sha256sums=('401813f1f89fa8fd4295805aa5284d9aed9bc7fc1fdbe554af4292f64cbabe21'
+sha256sums=('cce88ebcffd3f790bde49caa75f97b9cc2dd54ca8f57e38c62707266ec71bc4e'
             'SKIP'
             '7fc584e69c156d7d9805b38912f07f417ccd1cce5fe4ee457761e8bea9128d04')
 validpgpkeys=('65F7C6B4206BD057A7EB73787180713BE58D1ADC') # VideoLAN Release Signing Key

--- a/msys2/PKGBUILD/40-mingw-w64-libopenmpt/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-libopenmpt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libopenmpt
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=0.8.3
+pkgver=0.8.4
 pkgrel=1
 pkgdesc="A cross-platform C++ and C library to decode tracked music files (modules) into a raw PCM audio stream (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-jellyfin-zlib"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools")
 source=("https://lib.openmpt.org/files/${_realname}/src/${_realname}-${pkgver}+release.autotools.tar.gz")
-sha256sums=('25d486a4da9728819274ed0959fd79a1c6358954710d54c14047c6457c8ca8ac')
+sha256sums=('627f9bf11aacae615a1f2c982c7e88cb21f11b2d6f0267946f7c82c5eae4943b')
 
 export MINGW_TOOLCHAIN_PREFIX="${MINGW_PREFIX}"
 export FF_MINGW_PREFIX="${MINGW_TOOLCHAIN_PREFIX}/ffbuild"

--- a/msys2/PKGBUILD/50-mingw-w64-libvpl/PKGBUILD
+++ b/msys2/PKGBUILD/50-mingw-w64-libvpl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libvpl
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=2.15.0
+pkgver=2.16.0
 pkgrel=1
 pkgdesc="Intel Video Processing Library (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Broad dependency refresh across build scripts, Docker builds, and MSYS2 PKGBUILDs to keep FFmpeg toolchains current.
> 
> - CI: update `shogo82148/actions-upload-release-asset` to `v1.9.2` in `_meta*.yaml`
> - Bump third‑party libs in `builder/scripts.d/*`: `openssl` (3.4.3), `xz` (5.8.2), `libxml2`, `zlib`, `freetype`, `gmp`, `fftw3f`, `vorbis`, X11 stack (`xcbproto`,`xorgproto`,`libxcb`,`libx11`,`libxext`), `AMF`, `dav1d`, `libass`, `libbluray`, `opus` (and drop AVX2 patch), `libvpl`, `libvpx`, `libwebp`, `openmpt`, `srt`, `zimg`, `zvbi`, Vulkan stack (`Vulkan-Headers`,`shaderc`,`SPIRV-Cross`)
> - Switch RKMPP repo to `nyanmisaka/rk-mirrors` and adjust artifact path for arm builds
> - Docker builds (`docker-build*.sh`): align versions for `libxml2`, `xz`, `dav1d`, `libvpl`, Intel media stack (`libdrm`,`libva`,`libva-utils`,`gmmlib`,`vpl-gpu-rt`,`media-driver`), Vulkan (`Headers`,`Loader`), `shaderc`, `openmpt`
> - MSYS2 packages: update `xz` (5.8.2), `libxml2` (2.15.1), `opus` (1.6 with Windows aarch64 features patch), `dav1d` (1.5.2), `libopenmpt` (0.8.4), `libvpl` (2.16.0)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fedbcdeee255372d80229df4343a8d71763bbb6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->